### PR TITLE
chore: createBidderParams is now named export and it receives object …

### DIFF
--- a/__test__/bot.test.ts
+++ b/__test__/bot.test.ts
@@ -11,7 +11,7 @@ import { afterAll, afterEach, expect, it, vi } from 'vitest';
 import * as fs from 'node:fs';
 import Path from 'node:path';
 import Bot from '../src/Bot.ts';
-import * as BidingRules from '../src/bidding-calculator/index.ts';
+import * as BiddingCalculator from '../src/bidding-calculator/index.ts';
 
 afterEach(teardown);
 afterAll(teardown);
@@ -40,7 +40,7 @@ it('can autobid and store stats', async () => {
     keysMnemonic: mnemonicGenerate(),
   });
 
-  vi.spyOn(BidingRules, 'default').mockImplementation(async () => {
+  vi.spyOn(BiddingCalculator, 'createBidderParams').mockImplementation(async () => {
     return {
       maxSeats: 10,
       bidDelay: 0,

--- a/src/AutoBidder.ts
+++ b/src/AutoBidder.ts
@@ -1,6 +1,7 @@
 import { type Accountset, CohortBidder, MiningBids } from '@argonprotocol/mainchain';
 import type { CohortStorage, ICohortBiddingStats } from './storage.ts';
-import createBidderParams from './bidding-calculator/index.ts';
+import { createBidderParams } from './bidding-calculator/index.ts';
+import { readJsonFileOrNull } from './utils.ts';
 
 /**
  * Creates a bidding process. Between each cohort, it will ask the callback for parameters for the next cohort.
@@ -52,10 +53,11 @@ export class AutoBidder {
 
   private async onBiddingStart(cohortId: number) {
     if (this.activeBidder?.cohortId === cohortId) return;
+    const biddingRules = readJsonFileOrNull(this.biddingRulesPath) || {};
     const params = await createBidderParams(
       cohortId,
       await this.accountset.client,
-      this.biddingRulesPath,
+      biddingRules,
     );
     if (params.maxSeats === 0) return;
     const startingStats = await this.storage.biddingFile(cohortId).get();

--- a/src/bidding-calculator/index.ts
+++ b/src/bidding-calculator/index.ts
@@ -1,13 +1,13 @@
 import { type ArgonClient } from '@argonprotocol/mainchain';
 import type { IBidderParams } from '../IBidderParams.ts';
 
-export default async function createBidderParams(
+export async function createBidderParams(
   cohortId: number,
   client: ArgonClient,
-  rulesPath: string,
+  biddingRules: any,
 ): Promise<IBidderParams> {
   const blockNumber = await client.rpc.chain.getHeader().then(x => x.number.toNumber());
-  console.warn('Bidding rules are not implemented yet', { cohortId, rulesPath, blockNumber });
+  console.warn('Bidding rules are not implemented yet', { cohortId, biddingRules, blockNumber });
   return {
     minBid: 0n,
     maxBid: 0n,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import { keyringFromFile, waitForLoad } from '@argonprotocol/mainchain';
-import { jsonExt, onExit, requireAll, requireEnv } from './utils.ts';
+import { jsonExt, onExit, requireAll, requireEnv, readJsonFileOrNull } from './utils.ts';
 import Bot from './Bot.ts';
 import express from 'express';
-import createBiddingRules from './bidding-calculator/index.ts';
+import { createBidderParams } from './bidding-calculator/index.ts';
 
 // wait for crypto wasm to be loaded
 await waitForLoad();
@@ -55,6 +55,8 @@ const server = app.listen(process.env.PORT ?? 3000, () => {
 });
 onExit(() => new Promise<void>(resolve => server.close(() => resolve())));
 
-await createBiddingRules(1, await bot.accountset.client, process.env.BIDDING_RULES_PATH!);
+
+const rulesContent = readJsonFileOrNull(process.env.BIDDING_RULES_PATH!) || {};
+await createBidderParams(1, await bot.accountset.client, rulesContent);
 await bot.start();
 onExit(() => bot.stop());

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,7 @@
 import { keyringFromFile, waitForLoad } from '@argonprotocol/mainchain';
-import { jsonExt, onExit, requireAll, requireEnv, readJsonFileOrNull } from './utils.ts';
+import { jsonExt, onExit, requireAll, requireEnv } from './utils.ts';
 import Bot from './Bot.ts';
 import express from 'express';
-import { createBidderParams } from './bidding-calculator/index.ts';
 
 // wait for crypto wasm to be loaded
 await waitForLoad();
@@ -55,8 +54,5 @@ const server = app.listen(process.env.PORT ?? 3000, () => {
 });
 onExit(() => new Promise<void>(resolve => server.close(() => resolve())));
 
-
-const rulesContent = readJsonFileOrNull(process.env.BIDDING_RULES_PATH!) || {};
-await createBidderParams(1, await bot.accountset.client, rulesContent);
 await bot.start();
 onExit(() => bot.stop());

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import * as Fs from 'node:fs';
 import express from 'express';
 
 export function onExit(fn: () => void | Promise<void>) {
@@ -42,4 +43,12 @@ export function jsonExt(data: any, response: express.Response) {
     2,
   );
   response.status(200).type('application/json').send(json);
+}
+
+export function readJsonFileOrNull(path: string) {
+  try {
+    return JSON.parse(Fs.readFileSync(path, 'utf8'));
+  } catch (error) {
+    return null;
+  }
 }


### PR DESCRIPTION
createBidderParams is now a named export.

Also, it needs to receive an object instead of a path since this is being used in a Vue frontend that has no access to the file system.